### PR TITLE
feat: define engine source registry and normalize schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ vercel dev --listen 127.0.0.1:4173
 | --- | --- | --- |
 | 제품 기획 | `./AiMediaWebsite.md` | 제품 정의, IA, 운영 엔진과 백오피스의 장기 방향을 정리한 기획서 |
 | 수동 발행 절차 | `./docs/manual-publishing-workflow.md` | 인터뷰로 검증된 수동 브리프를 먼저 발행해 MVP를 검증하고, 자동 수집·자동 발행 엔진은 아직 만들지 않는 절차 |
+| 엔진 v0 소스 모델 | `./docs/engine-source-registry.md` | 공식 소스 레지스트리, normalize-layer 계약, config와 code의 경계를 정의한 첫 엔진 문서 |
+| 초기 소스 레지스트리 | `./engine/source-registry.json` | OpenAI, Anthropic, Cursor, Vercel, Supabase의 초기 공식 소스 인벤토리 |
 | 퍼블릭 웹 기본값 | `./docs/public-web-basics.md` | canonical, robots, sitemap, favicon, social metadata 같은 public-web 기본 정책 |
 | ICP·인터뷰 스크립트 | `./docs/icp-outreach-scripts.md` | 초기 ICP 검증과 인터뷰 진행에 쓰는 스크립트와 응답 인사이트 |
 | 설계(office-hours) | `external local note` | 구조와 방향성을 보완하는 설계 메모. 현재 레포 바깥 로컬 초안이라 저장소에서는 직접 열리지 않는다. |

--- a/docs/engine-source-registry.md
+++ b/docs/engine-source-registry.md
@@ -111,7 +111,7 @@ The initial registry covers the first tracked vendor set from the product brief:
 
 | Vendor | Included sources | Why they are in v0 |
 | --- | --- | --- |
-| OpenAI | API changelog, API deprecations, ChatGPT release notes | highest editorial priority and already used in seed briefs; ChatGPT release notes stay manual until access constraints are solved |
+| OpenAI | API changelog, API deprecations, ChatGPT release notes | highest editorial priority and already used in seed briefs; ChatGPT release notes stay `manual` and `draft` until access constraints are solved |
 | Anthropic | release notes overview, Claude Help Center release notes, model deprecations | strong comparator vendor for API and workspace changes |
 | Cursor | changelog | primary coding-tool desk and interview-backed follow-up seed |
 | Vercel | changelog | deploy, runtime, and pricing changes often overlap with API work |

--- a/docs/engine-source-registry.md
+++ b/docs/engine-source-registry.md
@@ -1,0 +1,139 @@
+# Engine v0 Source Registry
+
+`Issue #12` defines the first engine slice: represent official vendor sources as config, then normalize raw source items into a stable shape that downstream briefing logic can trust.
+
+## Goals
+
+- keep the first engine asset config-first instead of hardcoding vendor logic in the fetcher
+- document the minimum `sources` and `source_items` contract before crawler work starts
+- encode the first vendor inventory for OpenAI, Anthropic, Cursor, Vercel, and Supabase
+- make the config/code boundary explicit so new vendors can be added without rewriting the engine
+
+## Design posture
+
+- Official sources are the final authority.
+- Community links can be a discovery signal, but not the final truth.
+- The registry should prefer reusable parser families over vendor-specific fetch code.
+- New vendors should be addable by config when they fit an existing parser family.
+
+## Source types
+
+| source_type | What it represents | Pollable in v0 | Typical trust level |
+| --- | --- | --- | --- |
+| `changelog` | dedicated vendor change log | yes | `official_primary` |
+| `release_notes` | product or app release notes | yes | `official_primary` |
+| `deprecations` | retirement or migration notices | yes | `official_primary` |
+| `docs` | official docs page used to confirm rollout behavior | yes | `official_secondary` |
+| `github_release` | official GitHub release page | yes | `official_github` |
+| `github_issue` | official GitHub issue or discussion used as a rollout notice | yes | `official_github` |
+| `email` | account-scoped vendor email notice | no, manual intake only | `official_account_email` |
+
+`email` is part of the model because the manual workflow already treats official email as a valid authority, but the first registry file only includes pollable web sources.
+
+## `sources` config contract
+
+The machine-readable definition lives in [`engine/source-registry.schema.json`](../engine/source-registry.schema.json) and the initial inventory lives in [`engine/source-registry.json`](../engine/source-registry.json).
+
+Each source record must carry:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `id` | yes | stable config key used by the engine |
+| `domain_id` | yes | owning domain, currently `ai-saas` |
+| `vendor_code` | yes | short vendor identifier such as `openai` |
+| `vendor_name` | yes | human-readable vendor label |
+| `name` | yes | source label shown in logs and admin views |
+| `source_type` | yes | one of the source types above |
+| `url` | yes | canonical official URL |
+| `is_official` | yes | final authority flag, must be `true` for the initial inventory |
+| `fetch_cadence` | yes | scheduler hint such as `hourly`, `daily`, or `manual` |
+| `parser_key` | yes | parser family key selected by config |
+| `status` | yes | `active`, `paused`, or `draft` |
+| `notes` | no | editorial or ingestion notes |
+
+## `source_items` capture and normalize contract
+
+The machine-readable contract lives in [`engine/source-item.schema.json`](../engine/source-item.schema.json).
+
+The raw capture layer keeps the minimal audit fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | internal item identifier |
+| `source_id` | source registry link |
+| `external_id` | vendor-provided item key when available |
+| `vendor_code` | normalized vendor label |
+| `title` | raw source title |
+| `url` | raw item URL |
+| `published_at` | item publish timestamp |
+| `raw_text` | extracted text body before interpretation |
+| `raw_fetched_at` | when the engine captured the item |
+| `fetch_status` | `ok`, `partial`, `error`, or `skipped` |
+
+The normalized object is the downstream contract used by briefing logic:
+
+| Field | Meaning |
+| --- | --- |
+| `event_key` | stable dedupe key for one vendor event |
+| `vendor_code` | vendor identifier repeated after normalization |
+| `source_type` | normalized source family |
+| `title` | normalized title |
+| `url` | canonical item URL |
+| `published_at` | normalized publish timestamp |
+| `topic` | narrow subject, for example `model retirement` or `edge runtime` |
+| `category` | site-facing category such as `models-api` or `deploy-infra` |
+| `trust_level` | authority grade such as `official_primary` |
+| `first_seen_via` | how the team first encountered the change |
+| `affected_track` | `operations`, `engineering`, `both`, or `undetermined` |
+| `impact_tags` | urgency or impact markers such as `breaking`, `cost`, `security` |
+| `official_source_links` | one or more authority links used for audit and publication |
+| `parser_key` | parser used to produce the item |
+| `parser_version` | parser revision string for traceability |
+| `summary_hint` | short neutral note for later content generation |
+
+This keeps the normalize layer focused on fact extraction and routing hints. Review decisions, approval state, and publishing state belong to `Issue #13`.
+
+## Initial vendor inventory
+
+The initial registry covers the first tracked vendor set from the product brief:
+
+| Vendor | Included sources | Why they are in v0 |
+| --- | --- | --- |
+| OpenAI | API changelog, API deprecations, ChatGPT release notes | highest editorial priority and already used in seed briefs |
+| Anthropic | release notes overview, Claude Help Center release notes, model deprecations | strong comparator vendor for API and workspace changes |
+| Cursor | changelog | primary coding-tool desk and interview-backed follow-up seed |
+| Vercel | changelog | deploy, runtime, and pricing changes often overlap with API work |
+| Supabase | changelog | infra, security, and dashboard changes fit the same audience |
+
+## Config ends here, code begins here
+
+Config owns:
+
+- domain definitions
+- vendor and source inventory
+- fetch cadence hints
+- parser selection by `parser_key`
+- stable category and trust labels used by normalization
+
+Code owns:
+
+- HTTP fetching and retry logic
+- parser implementations keyed by `parser_key`
+- text extraction, checksuming, and dedupe
+- normalized item validation against schema
+- storage adapters, review pipeline, and publishing pipeline
+
+The handoff rule is simple:
+
+- if a new vendor fits an existing `source_type` and `parser_key`, add config only
+- if a new source shape does not fit an existing parser family, add one parser in code and then reference it from config
+
+That keeps vendor expansion mostly data-driven while still allowing parser code to stay generic and reusable.
+
+## Files added in this slice
+
+- [`engine/source-registry.schema.json`](../engine/source-registry.schema.json)
+- [`engine/source-registry.json`](../engine/source-registry.json)
+- [`engine/source-item.schema.json`](../engine/source-item.schema.json)
+
+These files are intentionally engine-facing assets, not crawler code. They are the contract that the first ingestion prototype should consume.

--- a/docs/engine-source-registry.md
+++ b/docs/engine-source-registry.md
@@ -15,7 +15,7 @@
 - Community links can be a discovery signal, but not the final truth.
 - The registry should prefer reusable parser families over vendor-specific fetch code.
 - New vendors should be addable by config when they fit an existing parser family.
-- Some official sources stay in the registry even when they are `manual` intake because the authority exists but is not bot-friendly.
+- Some official sources are documented first and only added to machine-readable config once ingestion is realistic.
 
 ## Source types
 
@@ -29,7 +29,7 @@
 | `github_issue` | official GitHub issue or discussion used as a rollout notice | yes | `official_github` |
 | `email` | account-scoped vendor email notice | no, manual intake only | `official_account_email` |
 
-`email` is part of the model because the manual workflow already treats official email as a valid authority. The first registry file mainly contains pollable web sources, but it may also include manual-only official pages when the source is important and browser-gated.
+`email` is part of the model because the manual workflow already treats official email as a valid authority. The first registry file keeps ingest-ready web sources, while manual-only authorities stay documented here until ingestion is realistic.
 
 ## `sources` config contract
 
@@ -111,7 +111,7 @@ The initial registry covers the first tracked vendor set from the product brief:
 
 | Vendor | Included sources | Why they are in v0 |
 | --- | --- | --- |
-| OpenAI | API changelog, API deprecations, ChatGPT release notes | highest editorial priority and already used in seed briefs; ChatGPT release notes stay `manual` and `draft` until access constraints are solved |
+| OpenAI | API changelog, API deprecations, ChatGPT release notes | highest editorial priority and already used in seed briefs; ChatGPT release notes stay documented as a deferred manual authority until access constraints are solved |
 | Anthropic | release notes overview, Claude Help Center release notes, model deprecations | strong comparator vendor for API and workspace changes |
 | Cursor | changelog | primary coding-tool desk and interview-backed follow-up seed |
 | Vercel | changelog | deploy, runtime, and pricing changes often overlap with API work |
@@ -141,6 +141,15 @@ The handoff rule is simple:
 - if a new source shape does not fit an existing parser family, add one parser in code and then reference it from config
 
 That keeps vendor expansion mostly data-driven while still allowing parser code to stay generic and reusable.
+
+## Deferred manual authorities
+
+These sources matter editorially, but are not yet part of the machine-readable registry because they are browser-gated or account-scoped:
+
+| Vendor | Source | Why deferred |
+| --- | --- | --- |
+| OpenAI | ChatGPT release notes | official help-center page is useful for workspace changes, but it is not yet reliable as an ingestion target |
+| Any vendor | official account email | authoritative for account-scoped changes, but capture is manual by nature |
 
 ## Files added in this slice
 

--- a/docs/engine-source-registry.md
+++ b/docs/engine-source-registry.md
@@ -15,6 +15,7 @@
 - Community links can be a discovery signal, but not the final truth.
 - The registry should prefer reusable parser families over vendor-specific fetch code.
 - New vendors should be addable by config when they fit an existing parser family.
+- Some official sources stay in the registry even when they are `manual` intake because the authority exists but is not bot-friendly.
 
 ## Source types
 
@@ -28,7 +29,7 @@
 | `github_issue` | official GitHub issue or discussion used as a rollout notice | yes | `official_github` |
 | `email` | account-scoped vendor email notice | no, manual intake only | `official_account_email` |
 
-`email` is part of the model because the manual workflow already treats official email as a valid authority, but the first registry file only includes pollable web sources.
+`email` is part of the model because the manual workflow already treats official email as a valid authority. The first registry file mainly contains pollable web sources, but it may also include manual-only official pages when the source is important and browser-gated.
 
 ## `sources` config contract
 
@@ -44,18 +45,29 @@ Each source record must carry:
 | `vendor_name` | yes | human-readable vendor label |
 | `name` | yes | source label shown in logs and admin views |
 | `source_type` | yes | one of the source types above |
-| `url` | yes | canonical official URL |
+| `url` | yes | official entry URL used by the registry |
 | `is_official` | yes | final authority flag, must be `true` for the initial inventory |
 | `fetch_cadence` | yes | scheduler hint such as `hourly`, `daily`, or `manual` |
 | `parser_key` | yes | parser family key selected by config |
 | `status` | yes | `active`, `paused`, or `draft` |
 | `notes` | no | editorial or ingestion notes |
 
+## Current parser families
+
+The initial registry uses a small parser family set instead of vendor-specific code:
+
+| `parser_key` | Intended source shape |
+| --- | --- |
+| `html-docs-changelog` | docs-driven changelog pages with repeated dated update blocks |
+| `html-docs-article` | docs pages that behave like a single article or policy page |
+| `help-center-release-notes` | help-center release notes pages with article chrome and chronological sections |
+| `html-site-changelog` | marketing-site changelog pages such as Cursor, Vercel, or Supabase |
+
 ## `source_items` capture and normalize contract
 
 The machine-readable contract lives in [`engine/source-item.schema.json`](../engine/source-item.schema.json).
 
-The raw capture layer keeps the minimal audit fields:
+The raw capture layer keeps the minimal audit fields. A `source_item` can exist immediately after fetch, before normalization is complete.
 
 | Field | Meaning |
 | --- | --- |
@@ -65,12 +77,12 @@ The raw capture layer keeps the minimal audit fields:
 | `vendor_code` | normalized vendor label |
 | `title` | raw source title |
 | `url` | raw item URL |
-| `published_at` | item publish timestamp |
-| `raw_text` | extracted text body before interpretation |
+| `published_at` | item publish timestamp when the source exposes one |
+| `raw_text` | extracted text body before interpretation when capture succeeds |
 | `raw_fetched_at` | when the engine captured the item |
 | `fetch_status` | `ok`, `partial`, `error`, or `skipped` |
 
-The normalized object is the downstream contract used by briefing logic:
+The normalized object is the downstream contract used by briefing logic. It is optional at capture time and appears only after the normalize step completes.
 
 | Field | Meaning |
 | --- | --- |
@@ -99,7 +111,7 @@ The initial registry covers the first tracked vendor set from the product brief:
 
 | Vendor | Included sources | Why they are in v0 |
 | --- | --- | --- |
-| OpenAI | API changelog, API deprecations, ChatGPT release notes | highest editorial priority and already used in seed briefs |
+| OpenAI | API changelog, API deprecations, ChatGPT release notes | highest editorial priority and already used in seed briefs; ChatGPT release notes stay manual until access constraints are solved |
 | Anthropic | release notes overview, Claude Help Center release notes, model deprecations | strong comparator vendor for API and workspace changes |
 | Cursor | changelog | primary coding-tool desk and interview-backed follow-up seed |
 | Vercel | changelog | deploy, runtime, and pricing changes often overlap with API work |
@@ -119,7 +131,7 @@ Code owns:
 
 - HTTP fetching and retry logic
 - parser implementations keyed by `parser_key`
-- text extraction, checksuming, and dedupe
+- text extraction, checksumming, and dedupe
 - normalized item validation against schema
 - storage adapters, review pipeline, and publishing pipeline
 

--- a/engine/source-item.schema.json
+++ b/engine/source-item.schema.json
@@ -8,13 +8,8 @@
     "id",
     "source_id",
     "vendor_code",
-    "title",
-    "url",
-    "published_at",
-    "raw_text",
     "raw_fetched_at",
-    "fetch_status",
-    "normalized"
+    "fetch_status"
   ],
   "properties": {
     "id": {
@@ -41,11 +36,11 @@
       "format": "uri"
     },
     "published_at": {
-      "type": "string",
+      "type": ["string", "null"],
       "format": "date-time"
     },
     "raw_text": {
-      "type": "string",
+      "type": ["string", "null"],
       "minLength": 1
     },
     "raw_fetched_at": {
@@ -57,6 +52,7 @@
       "enum": ["ok", "partial", "error", "skipped"]
     },
     "normalized": {
+      "description": "Optional normalize-layer payload. This is absent until normalization succeeds.",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -177,5 +173,33 @@
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "fetch_status": {
+            "enum": ["ok", "partial"]
+          }
+        },
+        "required": ["fetch_status"]
+      },
+      "then": {
+        "required": ["title", "url"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "fetch_status": {
+            "const": "ok"
+          }
+        },
+        "required": ["fetch_status"]
+      },
+      "then": {
+        "required": ["raw_text"]
+      }
+    }
+  ]
 }

--- a/engine/source-item.schema.json
+++ b/engine/source-item.schema.json
@@ -40,8 +40,7 @@
       "format": "date-time"
     },
     "raw_text": {
-      "type": ["string", "null"],
-      "minLength": 1
+      "type": ["string", "null"]
     },
     "raw_fetched_at": {
       "type": "string",
@@ -53,7 +52,7 @@
     },
     "normalized": {
       "description": "Optional normalize-layer payload. This is absent until normalization succeeds.",
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": false,
       "required": [
         "event_key",
@@ -198,7 +197,13 @@
         "required": ["fetch_status"]
       },
       "then": {
-        "required": ["raw_text"]
+        "required": ["raw_text"],
+        "properties": {
+          "raw_text": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
       }
     }
   ]

--- a/engine/source-item.schema.json
+++ b/engine/source-item.schema.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aimedia.engine/source-item.schema.json",
+  "title": "AiMedia source item",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "source_id",
+    "vendor_code",
+    "title",
+    "url",
+    "published_at",
+    "raw_text",
+    "raw_fetched_at",
+    "fetch_status",
+    "normalized"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "external_id": {
+      "type": ["string", "null"]
+    },
+    "vendor_code": {
+      "type": "string",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "url": {
+      "type": "string",
+      "format": "uri"
+    },
+    "published_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "raw_text": {
+      "type": "string",
+      "minLength": 1
+    },
+    "raw_fetched_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "fetch_status": {
+      "type": "string",
+      "enum": ["ok", "partial", "error", "skipped"]
+    },
+    "normalized": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_key",
+        "vendor_code",
+        "source_type",
+        "title",
+        "url",
+        "published_at",
+        "topic",
+        "category",
+        "trust_level",
+        "official_source_links"
+      ],
+      "properties": {
+        "event_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "vendor_code": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "source_type": {
+          "type": "string",
+          "enum": [
+            "changelog",
+            "release_notes",
+            "deprecations",
+            "docs",
+            "github_release",
+            "github_issue",
+            "email"
+          ]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "topic": {
+          "type": "string",
+          "minLength": 1
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "models-api",
+            "coding-tools",
+            "deploy-infra",
+            "billing-plan",
+            "automation-agents",
+            "governance-policy",
+            "security-compliance",
+            "docs-education",
+            "workspace-apps",
+            "other"
+          ]
+        },
+        "trust_level": {
+          "type": "string",
+          "enum": [
+            "official_primary",
+            "official_secondary",
+            "official_account_email",
+            "official_github",
+            "community_signal"
+          ]
+        },
+        "first_seen_via": {
+          "type": "string"
+        },
+        "affected_track": {
+          "type": "string",
+          "enum": ["operations", "engineering", "both", "undetermined"]
+        },
+        "impact_tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "breaking",
+              "cost",
+              "security",
+              "education",
+              "deployment",
+              "policy",
+              "reliability",
+              "migration"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "official_source_links": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "parser_key": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "parser_version": {
+          "type": "string"
+        },
+        "summary_hint": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/engine/source-registry.json
+++ b/engine/source-registry.json
@@ -1,0 +1,139 @@
+{
+  "version": 1,
+  "domains": [
+    {
+      "id": "ai-saas",
+      "code": "ai-saas",
+      "name": "AI and SaaS updates",
+      "status": "active"
+    }
+  ],
+  "sources": [
+    {
+      "id": "openai-api-changelog",
+      "domain_id": "ai-saas",
+      "vendor_code": "openai",
+      "vendor_name": "OpenAI",
+      "name": "OpenAI API changelog",
+      "source_type": "changelog",
+      "url": "https://developers.openai.com/api/docs/changelog",
+      "is_official": true,
+      "fetch_cadence": "hourly",
+      "parser_key": "html-docs-changelog",
+      "status": "active",
+      "notes": "Primary API change log for models, endpoints, billing, and migration-impact items."
+    },
+    {
+      "id": "openai-api-deprecations",
+      "domain_id": "ai-saas",
+      "vendor_code": "openai",
+      "vendor_name": "OpenAI",
+      "name": "OpenAI API deprecations",
+      "source_type": "deprecations",
+      "url": "https://developers.openai.com/api/docs/deprecations",
+      "is_official": true,
+      "fetch_cadence": "daily",
+      "parser_key": "html-docs-article",
+      "status": "active",
+      "notes": "Lifecycle and retirement notices with replacement guidance."
+    },
+    {
+      "id": "openai-chatgpt-release-notes",
+      "domain_id": "ai-saas",
+      "vendor_code": "openai",
+      "vendor_name": "OpenAI",
+      "name": "ChatGPT release notes",
+      "source_type": "release_notes",
+      "url": "https://help.openai.com/en/articles/6825453-chatgpt-release-notes",
+      "is_official": true,
+      "fetch_cadence": "daily",
+      "parser_key": "help-center-release-notes",
+      "status": "active",
+      "notes": "Workspace and app-facing changes that may matter to operations teams."
+    },
+    {
+      "id": "anthropic-release-notes-overview",
+      "domain_id": "ai-saas",
+      "vendor_code": "anthropic",
+      "vendor_name": "Anthropic",
+      "name": "Anthropic release notes overview",
+      "source_type": "release_notes",
+      "url": "https://platform.claude.com/docs/en/release-notes/overview",
+      "is_official": true,
+      "fetch_cadence": "daily",
+      "parser_key": "html-docs-article",
+      "status": "active",
+      "notes": "Landing page for Anthropic API and app updates."
+    },
+    {
+      "id": "anthropic-help-center-release-notes",
+      "domain_id": "ai-saas",
+      "vendor_code": "anthropic",
+      "vendor_name": "Anthropic",
+      "name": "Claude Help Center release notes",
+      "source_type": "release_notes",
+      "url": "https://support.claude.com/en/articles/12138966-release-notes",
+      "is_official": true,
+      "fetch_cadence": "daily",
+      "parser_key": "help-center-release-notes",
+      "status": "active",
+      "notes": "Workspace and Claude app release notes for end-user and admin-facing changes."
+    },
+    {
+      "id": "anthropic-model-deprecations",
+      "domain_id": "ai-saas",
+      "vendor_code": "anthropic",
+      "vendor_name": "Anthropic",
+      "name": "Anthropic model deprecations",
+      "source_type": "deprecations",
+      "url": "https://platform.claude.com/docs/en/about-claude/model-deprecations",
+      "is_official": true,
+      "fetch_cadence": "daily",
+      "parser_key": "html-docs-article",
+      "status": "active",
+      "notes": "Retirement schedule and replacement guidance for Claude model families."
+    },
+    {
+      "id": "cursor-changelog",
+      "domain_id": "ai-saas",
+      "vendor_code": "cursor",
+      "vendor_name": "Cursor",
+      "name": "Cursor changelog",
+      "source_type": "changelog",
+      "url": "https://cursor.com/changelog",
+      "is_official": true,
+      "fetch_cadence": "daily",
+      "parser_key": "html-site-changelog",
+      "status": "active",
+      "notes": "Primary source for IDE, agent, plugin, and workflow changes."
+    },
+    {
+      "id": "vercel-changelog",
+      "domain_id": "ai-saas",
+      "vendor_code": "vercel",
+      "vendor_name": "Vercel",
+      "name": "Vercel changelog",
+      "source_type": "changelog",
+      "url": "https://vercel.com/changelog",
+      "is_official": true,
+      "fetch_cadence": "daily",
+      "parser_key": "html-site-changelog",
+      "status": "active",
+      "notes": "Runtime, deploy, pricing, and platform changes that overlap with engineering operations."
+    },
+    {
+      "id": "supabase-changelog",
+      "domain_id": "ai-saas",
+      "vendor_code": "supabase",
+      "vendor_name": "Supabase",
+      "name": "Supabase changelog",
+      "source_type": "changelog",
+      "url": "https://supabase.com/changelog",
+      "is_official": true,
+      "fetch_cadence": "daily",
+      "parser_key": "html-site-changelog",
+      "status": "active",
+      "notes": "Database, auth, edge, billing, and security-impact product updates."
+    }
+  ]
+}

--- a/engine/source-registry.json
+++ b/engine/source-registry.json
@@ -38,20 +38,6 @@
       "notes": "Lifecycle and retirement notices with replacement guidance."
     },
     {
-      "id": "openai-chatgpt-release-notes",
-      "domain_id": "ai-saas",
-      "vendor_code": "openai",
-      "vendor_name": "OpenAI",
-      "name": "ChatGPT release notes",
-      "source_type": "release_notes",
-      "url": "https://help.openai.com/en/articles/6825453-chatgpt-release-notes",
-      "is_official": true,
-      "fetch_cadence": "manual",
-      "parser_key": "help-center-release-notes",
-      "status": "draft",
-      "notes": "Workspace and app-facing changes that may matter to operations teams. Keep manual and draft until the ingestion layer can handle Help Center access controls."
-    },
-    {
       "id": "anthropic-release-notes-overview",
       "domain_id": "ai-saas",
       "vendor_code": "anthropic",

--- a/engine/source-registry.json
+++ b/engine/source-registry.json
@@ -48,8 +48,8 @@
       "is_official": true,
       "fetch_cadence": "manual",
       "parser_key": "help-center-release-notes",
-      "status": "active",
-      "notes": "Workspace and app-facing changes that may matter to operations teams. Keep manual until the ingestion layer can handle Help Center access controls."
+      "status": "draft",
+      "notes": "Workspace and app-facing changes that may matter to operations teams. Keep manual and draft until the ingestion layer can handle Help Center access controls."
     },
     {
       "id": "anthropic-release-notes-overview",

--- a/engine/source-registry.json
+++ b/engine/source-registry.json
@@ -16,7 +16,7 @@
       "vendor_name": "OpenAI",
       "name": "OpenAI API changelog",
       "source_type": "changelog",
-      "url": "https://developers.openai.com/api/docs/changelog",
+      "url": "https://developers.openai.com/docs/changelog",
       "is_official": true,
       "fetch_cadence": "hourly",
       "parser_key": "html-docs-changelog",
@@ -46,10 +46,10 @@
       "source_type": "release_notes",
       "url": "https://help.openai.com/en/articles/6825453-chatgpt-release-notes",
       "is_official": true,
-      "fetch_cadence": "daily",
+      "fetch_cadence": "manual",
       "parser_key": "help-center-release-notes",
       "status": "active",
-      "notes": "Workspace and app-facing changes that may matter to operations teams."
+      "notes": "Workspace and app-facing changes that may matter to operations teams. Keep manual until the ingestion layer can handle Help Center access controls."
     },
     {
       "id": "anthropic-release-notes-overview",

--- a/engine/source-registry.schema.json
+++ b/engine/source-registry.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aimedia.engine/source-registry.schema.json",
+  "title": "AiMedia source registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "domains", "sources"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "domains": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "code", "name", "status"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "code": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "paused", "draft"]
+          }
+        }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "domain_id",
+          "vendor_code",
+          "vendor_name",
+          "name",
+          "source_type",
+          "url",
+          "is_official",
+          "fetch_cadence",
+          "parser_key",
+          "status"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "domain_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "vendor_code": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "vendor_name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_type": {
+            "type": "string",
+            "enum": [
+              "changelog",
+              "release_notes",
+              "deprecations",
+              "docs",
+              "github_release",
+              "github_issue",
+              "email"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "is_official": {
+            "type": "boolean"
+          },
+          "fetch_cadence": {
+            "type": "string",
+            "enum": ["hourly", "daily", "manual"]
+          },
+          "parser_key": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "paused", "draft"]
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/engine/source-registry.schema.json
+++ b/engine/source-registry.schema.json
@@ -102,7 +102,8 @@
           },
           "parser_key": {
             "type": "string",
-            "pattern": "^[a-z0-9-]+$"
+            "pattern": "^[a-z0-9-]+$",
+            "description": "Parser family key. Current v0 examples: html-docs-changelog, html-docs-article, help-center-release-notes, html-site-changelog."
           },
           "status": {
             "type": "string",


### PR DESCRIPTION
## Summary
- add an engine v0 design document for the official-source registry and normalize-layer contract
- add machine-readable schema and inventory files for `sources` and `source_items`
- document the first official source inventory for OpenAI, Anthropic, Cursor, Vercel, and Supabase

## Verification
- `python3 -m json.tool engine/source-registry.json >/dev/null`
- `python3 -m json.tool engine/source-registry.schema.json >/dev/null`
- `python3 -m json.tool engine/source-item.schema.json >/dev/null`

Closes #12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds documentation and JSON config/schema files with no runtime logic changes.
> 
> **Overview**
> Defines the first *engine v0* contract for ingesting official vendor updates by adding JSON Schemas for `source-registry` and `source-items` (including the normalized downstream shape).
> 
> Adds an initial `engine/source-registry.json` inventory for OpenAI, Anthropic, Cursor, Vercel, and Supabase (with `fetch_cadence` + `parser_key` hints), and links the new engine docs/files from `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a1bfb93cf5f30d6f84765a81f53d8abd92df178. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation and configuration schemas for the source registry system. New documentation outlines the config-first model for vendor sources and normalized items.
  * Includes JSON schema definitions for source item and registry validation, plus an initial inventory of official documentation sources from OpenAI, Anthropic, Cursor, Vercel, and Supabase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->