### PR TITLE
feat: define engine review and publishing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ vercel dev --listen 127.0.0.1:4173
 | 수동 발행 절차 | `./docs/manual-publishing-workflow.md` | 인터뷰로 검증된 수동 브리프를 먼저 발행해 MVP를 검증하고, 자동 수집·자동 발행 엔진은 아직 만들지 않는 절차 |
 | 엔진 v0 소스 모델 | `./docs/engine-source-registry.md` | 공식 소스 레지스트리, normalize-layer 계약, config와 code의 경계를 정의한 첫 엔진 문서 |
 | 초기 소스 레지스트리 | `./engine/source-registry.json` | OpenAI, Anthropic, Cursor, Vercel, Supabase의 초기 공식 소스 인벤토리 |
+| 엔진 v0 리뷰/발행 모델 | `./docs/engine-review-publishing-workflow.md` | 상태 모델, 리뷰 룰, publish artifact 관계, 수동/자동 경계를 정의한 워크플로우 문서 |
+| 초기 리뷰 룰셋 | `./engine/review-rules.json` | approval 이전에 반드시 통과해야 하는 최소 리뷰 규칙 |
+| 초기 상태 모델 | `./engine/workflow-state.json` | `content_jobs`, `articles`, `review_logs`, `channel_package`의 상태와 전이 정의 |
 | 퍼블릭 웹 기본값 | `./docs/public-web-basics.md` | canonical, robots, sitemap, favicon, social metadata 같은 public-web 기본 정책 |
 | ICP·인터뷰 스크립트 | `./docs/icp-outreach-scripts.md` | 초기 ICP 검증과 인터뷰 진행에 쓰는 스크립트와 응답 인사이트 |
 | 설계(office-hours) | `external local note` | 구조와 방향성을 보완하는 설계 메모. 현재 레포 바깥 로컬 초안이라 저장소에서는 직접 열리지 않는다. |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ vercel dev --listen 127.0.0.1:4173
 | 초기 소스 레지스트리 | `./engine/source-registry.json` | OpenAI, Anthropic, Cursor, Vercel, Supabase의 초기 공식 소스 인벤토리 |
 | 엔진 v0 리뷰/발행 모델 | `./docs/engine-review-publishing-workflow.md` | 상태 모델, 리뷰 룰, publish artifact 관계, 수동/자동 경계를 정의한 워크플로우 문서 |
 | 초기 리뷰 룰셋 | `./engine/review-rules.json` | approval 이전에 반드시 통과해야 하는 최소 리뷰 규칙 |
-| 초기 상태 모델 | `./engine/workflow-state.json` | `content_jobs`, `articles`, `review_logs`, `channel_package`의 상태와 전이 정의 |
+| 초기 상태 모델 | `./engine/workflow-state.json` | `content_job`, `article`, `review_log`, `channel_package`의 상태와 전이 정의 |
 | 퍼블릭 웹 기본값 | `./docs/public-web-basics.md` | canonical, robots, sitemap, favicon, social metadata 같은 public-web 기본 정책 |
 | ICP·인터뷰 스크립트 | `./docs/icp-outreach-scripts.md` | 초기 ICP 검증과 인터뷰 진행에 쓰는 스크립트와 응답 인사이트 |
 | 설계(office-hours) | `external local note` | 구조와 방향성을 보완하는 설계 메모. 현재 레포 바깥 로컬 초안이라 저장소에서는 직접 열리지 않는다. |

--- a/docs/engine-review-publishing-workflow.md
+++ b/docs/engine-review-publishing-workflow.md
@@ -1,0 +1,191 @@
+# Engine v0 Review and Publishing Workflow
+
+`Issue #13` turns the editorial workflow into an implementation contract. The engine already has a source registry and normalized source-item shape from [`Issue #12`](./engine-source-registry.md); this document defines what happens after a source item exists.
+
+## Goal
+
+- define the lifecycle from normalized source item to published article
+- make review rules explicit enough to implement as code
+- separate `content_jobs`, `articles`, and `review_logs` into clear responsibilities
+- show where manual review still owns the decision and where future automation can take over
+
+## Workflow records
+
+| Record | What it represents | Created when |
+| --- | --- | --- |
+| `source_item` | one normalized vendor update candidate | after fetch + normalize |
+| `content_job` | one attempt to turn a source item into publishable content | when the editorial engine accepts a source item |
+| `article` | the web-facing brief or explainer draft | when generation produces a draft body |
+| `review_log` | one rule evaluation result attached to an article or job | whenever a rule runs |
+| `channel_package` | derived packaging for web index, newsletter, or future dispatch channels | after approval or scheduling |
+
+## Relationship model
+
+The minimum implementation relationship is:
+
+- one `source_item` can spawn zero or more `content_jobs`
+- one `content_job` owns exactly one current `article` draft
+- one `article` can accumulate many `review_logs`
+- one approved `article` can feed many `channel_package` records over time
+
+This allows:
+
+- retries without mutating the original `source_item`
+- article rewrites without losing review history
+- web publishing and newsletter packaging to diverge while sharing the same approved content source
+
+## State model
+
+The machine-readable definition lives in [`engine/workflow-state.json`](../engine/workflow-state.json).
+
+### `content_jobs.status`
+
+| State | Meaning | Typical owner |
+| --- | --- | --- |
+| `queued` | accepted candidate, waiting for generation or enrichment | automation |
+| `processing` | generation or rule preflight is currently running | automation |
+| `needs_review` | draft exists, but a human must check authority, impact, or wording | editor |
+| `approved` | job output is editorially valid and can create scheduled channel output | editor |
+| `rejected` | candidate should not proceed because it is weak, duplicate, or low-impact | editor |
+| `archived` | job is kept for audit, but no longer active | automation or editor |
+
+### `articles.review_status`
+
+| State | Meaning | Typical owner |
+| --- | --- | --- |
+| `draft` | first article body exists, but review has not started | automation |
+| `needs_review` | manual review required before any scheduling | editor |
+| `approved` | article is clean and can move to channel planning | editor |
+| `scheduled` | article is assigned a publish window or batch | editor |
+| `published` | article is live on the web surface | automation or editor |
+| `rejected` | article draft should not ship | editor |
+| `archived` | article is no longer active, but remains for audit and duplicate checks | automation or editor |
+
+### State transitions
+
+```mermaid
+flowchart LR
+  source["source_item (normalized)"] --> jobq["content_job: queued"]
+  jobq --> jobp["processing"]
+  jobp --> artd["article: draft"]
+  artd --> jobr["content_job: needs_review"]
+  jobr --> artr["article: needs_review"]
+  artr --> arta["article: approved"]
+  arta --> jobs["content_job: approved"]
+  arta --> arts["article: scheduled"]
+  arts --> artp["article: published"]
+  jobr --> jobx["content_job: rejected"]
+  artr --> artx["article: rejected"]
+  jobs --> pack["channel_package"]
+  artp --> pack
+  jobx --> arcv["archived records"]
+  artx --> arcv
+```
+
+## Minimum review rules
+
+The machine-readable rule set lives in [`engine/review-rules.json`](../engine/review-rules.json).
+
+The initial blocking rules are:
+
+| Rule key | Why it exists | Blocks approval |
+| --- | --- | --- |
+| `official_source_first` | prevent non-authoritative briefs | yes |
+| `practical_impact_present` | force the article to explain operational or engineering consequences | yes |
+| `what_to_do_now_present` | force a concrete action block | yes |
+| `cta_present` | keep the article aligned with the site template and user flow | yes |
+| `duplicate_title_exact` | stop exact duplicate publish attempts | yes |
+| `duplicate_similarity` | flag near-duplicate angles before publish | yes |
+
+Supporting manual checks can still emit warnings instead of hard failure, but the approval gate should not be bypassed if any blocking rule fails.
+
+## Rule execution order
+
+1. `processing`
+   Run deterministic structure checks on the draft and create initial `review_logs`.
+2. `needs_review`
+   Human editor confirms authority, impact, audience track, and actionability.
+3. `approved`
+   Approval only happens if all blocking rules are `pass`.
+4. `scheduled`
+   Channel packaging can begin after approval.
+5. `published`
+   Publish writes the final web artifact and closes the workflow loop.
+
+## Publishing layer responsibilities
+
+### Web publish
+
+- writes the article detail page
+- updates the homepage/latest queue when relevant
+- updates hubs such as briefs, weekly, categories, or tools if the item belongs there
+
+### Newsletter packaging
+
+- groups approved articles into a weekly or campaign batch
+- produces newsletter subject, summary blocks, and article order
+- does not replace article approval; it consumes already approved content
+
+### Future channel dispatch
+
+- Slack, Telegram, or email snippets should be treated as derived channel packages
+- dispatch can be automated later, but only from approved articles
+- dispatch failure should not roll back web publication
+
+## Manual review boundary
+
+Manual review still owns:
+
+- deciding whether the update is worth publishing at all
+- confirming that the official-source set is sufficient
+- checking whether the article really states practical impact
+- confirming track fit: `operations`, `engineering`, or `both`
+- choosing publish timing, homepage placement, and newsletter inclusion
+
+Automation can own:
+
+- enqueueing jobs from normalized source items
+- generating draft bodies and share blocks
+- running deterministic review rules
+- exact duplicate detection
+- preparing web and newsletter packaging records after approval
+
+## Review log contract
+
+`review_logs` should be append-only and minimal:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | stable log identifier |
+| `article_id` | article being checked |
+| `rule_key` | rule that ran |
+| `result` | `pass`, `fail`, `warn`, or `skip` |
+| `message` | human-readable explanation |
+| `created_at` | timestamp of the evaluation |
+
+This keeps the audit trail stable even if the article or rule definitions evolve.
+
+## Implementation boundary
+
+This slice should stop at workflow definition and config.
+
+Config owns:
+
+- state labels and allowed transitions
+- rule definitions and blocking/warning behavior
+- channel package types
+
+Code owns:
+
+- job orchestration
+- rule execution
+- duplicate detection implementation
+- article rendering and publish side effects
+- newsletter and future channel dispatch adapters
+
+## Files added in this slice
+
+- [`engine/workflow-state.json`](../engine/workflow-state.json)
+- [`engine/review-rules.json`](../engine/review-rules.json)
+
+These files are implementation-facing contracts for the next engine issues, not the implementation itself.

--- a/docs/engine-review-publishing-workflow.md
+++ b/docs/engine-review-publishing-workflow.md
@@ -23,10 +23,10 @@
 
 The minimum implementation relationship is:
 
-- one `source_item` can spawn zero or more `content_jobs`
+- one `source_item` can spawn zero or more `content_job` records
 - one `content_job` owns exactly one current `article` draft
-- one `content_job` can accumulate many `review_logs` during preflight or rejection checks
-- one `article` can accumulate many `review_logs` after a draft exists
+- one `content_job` can accumulate many `review_log` records during preflight or rejection checks
+- one `article` can accumulate many `review_log` records after a draft exists
 - one approved `article` can feed many `channel_package` records over time
 
 This allows:

--- a/docs/engine-review-publishing-workflow.md
+++ b/docs/engine-review-publishing-workflow.md
@@ -6,7 +6,7 @@
 
 - define the lifecycle from normalized source item to published article
 - make review rules explicit enough to implement as code
-- separate `content_jobs`, `articles`, and `review_logs` into clear responsibilities
+- separate `content_job`, `article`, and `review_log` into clear responsibilities
 - show where manual review still owns the decision and where future automation can take over
 
 ## Workflow records
@@ -16,7 +16,7 @@
 | `source_item` | one normalized vendor update candidate | after fetch + normalize |
 | `content_job` | one attempt to turn a source item into publishable content | when the editorial engine accepts a source item |
 | `article` | the web-facing brief or explainer draft | when generation produces a draft body |
-| `review_log` | one rule evaluation result attached to an article or job | whenever a rule runs |
+| `review_log` | one rule evaluation result attached to either an article or a content job | whenever a rule runs |
 | `channel_package` | derived packaging for web index, newsletter, or future dispatch channels | after approval or scheduling |
 
 ## Relationship model
@@ -25,7 +25,8 @@ The minimum implementation relationship is:
 
 - one `source_item` can spawn zero or more `content_jobs`
 - one `content_job` owns exactly one current `article` draft
-- one `article` can accumulate many `review_logs`
+- one `content_job` can accumulate many `review_logs` during preflight or rejection checks
+- one `article` can accumulate many `review_logs` after a draft exists
 - one approved `article` can feed many `channel_package` records over time
 
 This allows:
@@ -38,7 +39,9 @@ This allows:
 
 The machine-readable definition lives in [`engine/workflow-state.json`](../engine/workflow-state.json).
 
-### `content_jobs.status`
+Config keys stay singular in JSON: `content_job`, `article`, `review_log`, and `channel_package`.
+
+### `content_job.status`
 
 | State | Meaning | Typical owner |
 | --- | --- | --- |
@@ -49,7 +52,7 @@ The machine-readable definition lives in [`engine/workflow-state.json`](../engin
 | `rejected` | candidate should not proceed because it is weak, duplicate, or low-impact | editor |
 | `archived` | job is kept for audit, but no longer active | automation or editor |
 
-### `articles.review_status`
+### `article.review_status`
 
 | State | Meaning | Typical owner |
 | --- | --- | --- |
@@ -86,6 +89,8 @@ flowchart LR
 
 The machine-readable rule set lives in [`engine/review-rules.json`](../engine/review-rules.json).
 
+Each rule declares both a `target` and a `phase_field`. In v0, the blocking rules inspect the `article` content but execute against `content_job.status` so preflight and editor checks share the same gate.
+
 The initial blocking rules are:
 
 | Rule key | Why it exists | Blocks approval |
@@ -101,15 +106,15 @@ Supporting manual checks can still emit warnings instead of hard failure, but th
 
 ## Rule execution order
 
-1. `processing`
+1. `content_job.processing`
    Run deterministic structure checks on the draft and create initial `review_logs`.
-2. `needs_review`
+2. `content_job.needs_review`
    Human editor confirms authority, impact, audience track, and actionability.
-3. `approved`
+3. `content_job.approved` and `article.approved`
    Approval only happens if all blocking rules are `pass`.
-4. `scheduled`
+4. `article.scheduled`
    Channel packaging can begin after approval.
-5. `published`
+5. `article.published`
    Publish writes the final web artifact and closes the workflow loop.
 
 ## Publishing layer responsibilities
@@ -152,18 +157,19 @@ Automation can own:
 
 ## Review log contract
 
-`review_logs` should be append-only and minimal:
+`review_logs` are append-only and contain only the following minimal fields.
 
 | Field | Meaning |
 | --- | --- |
 | `id` | stable log identifier |
-| `article_id` | article being checked |
+| `article_id` | article being checked when the log is article-scoped |
+| `content_job_id` | content job being checked when the log is job-scoped |
 | `rule_key` | rule that ran |
 | `result` | `pass`, `fail`, `warn`, or `skip` |
 | `message` | human-readable explanation |
 | `created_at` | timestamp of the evaluation |
 
-This keeps the audit trail stable even if the article or rule definitions evolve.
+Exactly one of `article_id` or `content_job_id` must be present on each log entry. This keeps the audit trail stable even if the article or rule definitions evolve.
 
 ## Implementation boundary
 

--- a/engine/review-rules.json
+++ b/engine/review-rules.json
@@ -1,0 +1,71 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "rule_key": "official_source_first",
+      "name": "Official source first",
+      "category": "authority",
+      "target": "article",
+      "phase": ["needs_review", "approved"],
+      "blocking": true,
+      "automation_level": "deterministic_plus_manual_confirmation",
+      "pass_condition": "The article links at least one official authority source and no non-official source is treated as the final authority.",
+      "failure_action": "Keep article in needs_review or reject it."
+    },
+    {
+      "rule_key": "practical_impact_present",
+      "name": "Practical impact present",
+      "category": "editorial_quality",
+      "target": "article",
+      "phase": ["processing", "needs_review", "approved"],
+      "blocking": true,
+      "automation_level": "structure_check_plus_manual_confirmation",
+      "pass_condition": "The article includes a practical impact section that states operational or engineering consequences.",
+      "failure_action": "Return to draft or keep in needs_review."
+    },
+    {
+      "rule_key": "what_to_do_now_present",
+      "name": "What to do now present",
+      "category": "actionability",
+      "target": "article",
+      "phase": ["processing", "needs_review", "approved"],
+      "blocking": true,
+      "automation_level": "structure_check_plus_manual_confirmation",
+      "pass_condition": "The article includes a specific what-to-do-now or this-week action block.",
+      "failure_action": "Return to draft or keep in needs_review."
+    },
+    {
+      "rule_key": "cta_present",
+      "name": "CTA present",
+      "category": "template",
+      "target": "article",
+      "phase": ["processing", "needs_review", "approved"],
+      "blocking": true,
+      "automation_level": "deterministic",
+      "pass_condition": "The article contains a CTA block that matches the current site template.",
+      "failure_action": "Return to draft."
+    },
+    {
+      "rule_key": "duplicate_title_exact",
+      "name": "Exact duplicate title check",
+      "category": "duplication",
+      "target": "article",
+      "phase": ["processing", "needs_review", "approved"],
+      "blocking": true,
+      "automation_level": "deterministic",
+      "pass_condition": "No existing published or scheduled article has the exact same normalized title.",
+      "failure_action": "Reject or rewrite before approval."
+    },
+    {
+      "rule_key": "duplicate_similarity",
+      "name": "Near-duplicate similarity check",
+      "category": "duplication",
+      "target": "article",
+      "phase": ["needs_review", "approved"],
+      "blocking": true,
+      "automation_level": "heuristic_plus_manual_confirmation",
+      "pass_condition": "No previously approved or published article exceeds the configured duplicate similarity threshold.",
+      "failure_action": "Escalate to editor for rewrite, merge, or rejection."
+    }
+  ]
+}

--- a/engine/review-rules.json
+++ b/engine/review-rules.json
@@ -6,66 +6,73 @@
       "name": "Official source first",
       "category": "authority",
       "target": "article",
-      "phase": ["needs_review", "approved"],
+      "phase_field": "content_job.status",
+      "phase": ["needs_review"],
       "blocking": true,
       "automation_level": "deterministic_plus_manual_confirmation",
       "pass_condition": "The article links at least one official authority source and no non-official source is treated as the final authority.",
-      "failure_action": "Keep article in needs_review or reject it."
+      "failure_action": "Keep the content_job in needs_review or reject it."
     },
     {
       "rule_key": "practical_impact_present",
       "name": "Practical impact present",
       "category": "editorial_quality",
       "target": "article",
-      "phase": ["processing", "needs_review", "approved"],
+      "phase_field": "content_job.status",
+      "phase": ["processing", "needs_review"],
       "blocking": true,
       "automation_level": "structure_check_plus_manual_confirmation",
       "pass_condition": "The article includes a practical impact section that states operational or engineering consequences.",
-      "failure_action": "Return to draft or keep in needs_review."
+      "failure_action": "Keep the content_job in needs_review and revise the article before approval."
     },
     {
       "rule_key": "what_to_do_now_present",
       "name": "What to do now present",
       "category": "actionability",
       "target": "article",
-      "phase": ["processing", "needs_review", "approved"],
+      "phase_field": "content_job.status",
+      "phase": ["processing", "needs_review"],
       "blocking": true,
       "automation_level": "structure_check_plus_manual_confirmation",
       "pass_condition": "The article includes a specific what-to-do-now or this-week action block.",
-      "failure_action": "Return to draft or keep in needs_review."
+      "failure_action": "Keep the content_job in needs_review and revise the article before approval."
     },
     {
       "rule_key": "cta_present",
       "name": "CTA present",
       "category": "template",
       "target": "article",
-      "phase": ["processing", "needs_review", "approved"],
+      "phase_field": "content_job.status",
+      "phase": ["processing", "needs_review"],
       "blocking": true,
       "automation_level": "deterministic",
       "pass_condition": "The article contains a CTA block that matches the current site template.",
-      "failure_action": "Return to draft."
+      "failure_action": "Keep the content_job in needs_review until the article matches the template."
     },
     {
       "rule_key": "duplicate_title_exact",
       "name": "Exact duplicate title check",
       "category": "duplication",
       "target": "article",
-      "phase": ["processing", "needs_review", "approved"],
+      "phase_field": "content_job.status",
+      "phase": ["processing", "needs_review"],
       "blocking": true,
       "automation_level": "deterministic",
       "pass_condition": "No existing published or scheduled article has the exact same normalized title.",
-      "failure_action": "Reject or rewrite before approval."
+      "failure_action": "Reject the content_job or revise the article before approval."
     },
     {
       "rule_key": "duplicate_similarity",
       "name": "Near-duplicate similarity check",
       "category": "duplication",
       "target": "article",
-      "phase": ["needs_review", "approved"],
+      "phase_field": "content_job.status",
+      "phase": ["needs_review"],
       "blocking": true,
       "automation_level": "heuristic_plus_manual_confirmation",
+      "similarity_threshold": 0.8,
       "pass_condition": "No previously approved or published article exceeds the configured duplicate similarity threshold.",
-      "failure_action": "Escalate to editor for rewrite, merge, or rejection."
+      "failure_action": "Keep the content_job in needs_review and escalate to an editor for rewrite, merge, or rejection."
     }
   ]
 }

--- a/engine/workflow-state.json
+++ b/engine/workflow-state.json
@@ -3,7 +3,7 @@
   "content_job": {
     "field": "status",
     "initial_state": "queued",
-    "terminal_states": ["approved", "rejected", "archived"],
+    "terminal_states": ["archived"],
     "states": [
       {
         "id": "queued",
@@ -48,7 +48,7 @@
   "article": {
     "field": "review_status",
     "initial_state": "draft",
-    "terminal_states": ["published", "rejected", "archived"],
+    "terminal_states": ["archived"],
     "states": [
       {
         "id": "draft",
@@ -99,7 +99,9 @@
   },
   "review_log": {
     "result_values": ["pass", "fail", "warn", "skip"],
-    "required_fields": ["id", "article_id", "rule_key", "result", "message", "created_at"]
+    "required_base_fields": ["id", "rule_key", "result", "message", "created_at"],
+    "record_ref_fields": ["article_id", "content_job_id"],
+    "record_ref_requirement": "exactly_one"
   },
   "channel_package": {
     "types": ["web_publish", "newsletter_batch", "future_dispatch"],

--- a/engine/workflow-state.json
+++ b/engine/workflow-state.json
@@ -1,0 +1,108 @@
+{
+  "version": 1,
+  "content_job": {
+    "field": "status",
+    "initial_state": "queued",
+    "terminal_states": ["approved", "rejected", "archived"],
+    "states": [
+      {
+        "id": "queued",
+        "description": "Accepted normalized source item waiting for generation.",
+        "owner": "automation"
+      },
+      {
+        "id": "processing",
+        "description": "Draft generation and preflight rule execution are running.",
+        "owner": "automation"
+      },
+      {
+        "id": "needs_review",
+        "description": "The draft exists and must be reviewed by an editor.",
+        "owner": "editor"
+      },
+      {
+        "id": "approved",
+        "description": "The job output is approved for publishing and channel packaging.",
+        "owner": "editor"
+      },
+      {
+        "id": "rejected",
+        "description": "The candidate should not continue because it is weak, duplicate, or low-impact.",
+        "owner": "editor"
+      },
+      {
+        "id": "archived",
+        "description": "The job is retained for audit but is no longer active.",
+        "owner": "editor_or_automation"
+      }
+    ],
+    "transitions": [
+      { "from": "queued", "to": "processing", "trigger": "generation_started" },
+      { "from": "processing", "to": "needs_review", "trigger": "draft_created" },
+      { "from": "needs_review", "to": "approved", "trigger": "all_blocking_rules_pass" },
+      { "from": "needs_review", "to": "rejected", "trigger": "editor_rejects_candidate" },
+      { "from": "approved", "to": "archived", "trigger": "workflow_closed" },
+      { "from": "rejected", "to": "archived", "trigger": "workflow_closed" }
+    ]
+  },
+  "article": {
+    "field": "review_status",
+    "initial_state": "draft",
+    "terminal_states": ["published", "rejected", "archived"],
+    "states": [
+      {
+        "id": "draft",
+        "description": "The first content body exists but has not entered review.",
+        "owner": "automation"
+      },
+      {
+        "id": "needs_review",
+        "description": "Manual review is required before scheduling or publish.",
+        "owner": "editor"
+      },
+      {
+        "id": "approved",
+        "description": "The article is ready for scheduling or direct publish.",
+        "owner": "editor"
+      },
+      {
+        "id": "scheduled",
+        "description": "The article has a publish slot or batch assignment.",
+        "owner": "editor"
+      },
+      {
+        "id": "published",
+        "description": "The article is live on the web surface.",
+        "owner": "automation_or_editor"
+      },
+      {
+        "id": "rejected",
+        "description": "The article draft should not ship.",
+        "owner": "editor"
+      },
+      {
+        "id": "archived",
+        "description": "The article stays available for audit and duplicate detection but is no longer active.",
+        "owner": "editor_or_automation"
+      }
+    ],
+    "transitions": [
+      { "from": "draft", "to": "needs_review", "trigger": "draft_ready_for_editor" },
+      { "from": "needs_review", "to": "approved", "trigger": "editor_approves" },
+      { "from": "needs_review", "to": "rejected", "trigger": "editor_rejects" },
+      { "from": "approved", "to": "scheduled", "trigger": "publish_window_assigned" },
+      { "from": "approved", "to": "published", "trigger": "publish_now" },
+      { "from": "scheduled", "to": "published", "trigger": "scheduled_publish_runs" },
+      { "from": "published", "to": "archived", "trigger": "retire_article" },
+      { "from": "rejected", "to": "archived", "trigger": "retain_for_audit" }
+    ]
+  },
+  "review_log": {
+    "result_values": ["pass", "fail", "warn", "skip"],
+    "required_fields": ["id", "article_id", "rule_key", "result", "message", "created_at"]
+  },
+  "channel_package": {
+    "types": ["web_publish", "newsletter_batch", "future_dispatch"],
+    "prerequisite_article_states": ["approved", "scheduled", "published"]
+  }
+}


### PR DESCRIPTION
## Summary
- add an engine v0 workflow document for state transitions, review rules, and publishing responsibilities
- add machine-readable workflow state and review rule config files for `content_jobs`, `articles`, `review_logs`, and `channel_package`
- document where manual review ends and future automation begins

## Verification
- `python3 -m json.tool engine/workflow-state.json >/dev/null`
- `python3 -m json.tool engine/review-rules.json >/dev/null`

Closes #13

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and new JSON config contracts only; no runtime code paths are modified, though future engine implementations will rely on these definitions.
> 
> **Overview**
> Defines the engine v0 *review → approval → scheduling → publishing* workflow as an implementation contract, including record relationships, state transitions, and clear manual-vs-automation boundaries.
> 
> Adds machine-readable configs for the workflow state machine (`engine/workflow-state.json`) and blocking review rules (`engine/review-rules.json`), and updates `README.md` to link these new engine documents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d95336b8176863eb1441fadd3d7c65423a000a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive editorial review-and-publishing workflow docs: state diagrams, record types, review-log contract, manual/automation boundaries, and responsibilities for publishing channels.

* **Chores**
  * Added configuration for deterministic review rules (including required sections, CTA checks, deduplication and escalation behavior) and a structured workflow state model for content jobs, articles, review logs, and channel packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->